### PR TITLE
Don't remove the key when job is executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- don't remove debounce key in redis to avoid invalid debouncing
+
 ## [2.0.0] - 2023-02-28
 Complete rewrite of the library:  
 - Instead of iterating through whole schedule set, sidekiq-debouncer will now cache debounce key in redis with a reference to the job.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Keep in mind that the result of the debounce method will be converted to string,
 
 In the application, call `MyWorker.perform_async(...)` as usual. Everytime you call this function, `MyWorker`'s execution will be postponed by 5 minutes. After that time `MyWorker` will receive a method call `perform` with an array of arguments that were provided to the `MyWorker.perform_async(...)` calls.
 
-To avoid keeping leftover keys in redis (for example, when job was manually removed from schedule set), all additional keys are created with TTL.
-It's 7 days by default and should be ok in most of the cases. If you are debouncing your jobs in higher interval than that, you can overwrite this setting:
+To avoid keeping leftover keys in redis, all additional keys are created with TTL.
+It's 24 hours by default and should be ok in most of the cases. If you are debouncing your jobs in higher interval than that, you can overwrite this setting:
 
 ```ruby
 Sidekiq.configure_client do |config|

--- a/lib/sidekiq/debouncer/middleware/client.rb
+++ b/lib/sidekiq/debouncer/middleware/client.rb
@@ -17,7 +17,7 @@ module Sidekiq
         REDIS_ERROR_CLASS = defined?(RedisClient::CommandError) ? RedisClient::CommandError : Redis::CommandError
 
         def initialize(options = {})
-          @debounce_key_ttl = options.fetch(:ttl, 60 * 60 * 24 * 7) # 7 days by default
+          @debounce_key_ttl = options.fetch(:ttl, 60 * 60 * 24) # 24 hours by default
         end
 
         def call(worker_class, job, _queue, _redis_pool)

--- a/lib/sidekiq/debouncer/middleware/server.rb
+++ b/lib/sidekiq/debouncer/middleware/server.rb
@@ -3,20 +3,13 @@
 module Sidekiq
   module Debouncer
     module Middleware
-      # Server middleware removes debounce key from redis before executing the job
+      # wrap args into array because sidekiq uses splat while calling perform
       class Server
         include Sidekiq::ServerMiddleware
 
         def call(_worker, job, _queue)
           if job.key?("debounce_key")
-            # skip if job comes from dead or retry set
-            unless job.key?("failed_at")
-              redis do |connection|
-                connection.call("DEL", job["debounce_key"])
-              end
-            end
-
-            job["args"] = [job["args"]] # wrap args into array because sidekiq uses splat while calling perform
+            job["args"] = [job["args"]]
           end
 
           yield

--- a/sidekiq-debouncer.gemspec
+++ b/sidekiq-debouncer.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |gem|
   gem.email = ["sebcioz@gmail.com", "kukicola@gmail.com"]
   gem.summary = "Sidekiq extension that adds the ability to debounce job execution"
   gem.description = <<~DESCRIPTION
+    Sidekiq extension that adds the ability to debounce job execution.
     Worker will postpone its execution after `wait time` have elapsed since the last time it was invoked.
     Useful for implementing behavior that should only happen after the input has stopped arriving.
   DESCRIPTION

--- a/spec/sidekiq/middleware/server_spec.rb
+++ b/spec/sidekiq/middleware/server_spec.rb
@@ -20,34 +20,6 @@ describe Sidekiq::Debouncer::Middleware::Client do
 
       expect_any_instance_of(TestWorker).to receive(:perform).with([["A", "job 1"], ["A", "job 2"]]).and_call_original
       processor.process_one
-
-      expect(Sidekiq.redis { |con| con.call("GET", "debounce/TestWorker/A") }).to be_nil
-    end
-  end
-
-  context "retry job" do
-    it "removes debounce key and wrap arguments only on first call" do
-      TestWorker.perform_async("A", "job 1")
-
-      expect(Sidekiq.redis { |con| con.call("GET", "debounce/TestWorker/A") }).not_to be_nil
-
-      Timecop.freeze(time_start + 10 * 60)
-      puller.enqueue # job now in the queue
-
-      allow_any_instance_of(TestWorker).to receive(:perform).with([["A", "job 1"]]).and_raise("something")
-      processor.process_one rescue nil # standard:disable Style/RescueModifier
-
-      expect(Sidekiq.redis { |con| con.call("GET", "debounce/TestWorker/A") }).to be_nil
-
-      Timecop.freeze(time_start + 20 * 60)
-      puller.enqueue # job in the queue again
-
-      TestWorker.perform_async("A", "job 2")
-      expect(Sidekiq.redis { |con| con.call("GET", "debounce/TestWorker/A") }).not_to be_nil
-
-      processor.process_one rescue nil # standard:disable Style/RescueModifier
-
-      expect(Sidekiq.redis { |con| con.call("GET", "debounce/TestWorker/A") }).not_to be_nil
     end
   end
 


### PR DESCRIPTION
Let's consider a case:
- job A is added to the schedule set and debounce key is created in redis
- job A is taken from schedule set and pushed to queue (and due to long queue it's waiting there)
- job B is added to the schedule set and new debounce key is created
- job A is processed and middleware removed debounce key created by job B
- job C is added to the schedule set and since debounce key was removed it won't be merged with job B

To fix that, we can keep debounce keys in redis and let them be removed automatically. Lua scripts checks if a job that is in debounce key exists in schedule set so it shouldn't lead to any problems