### PR TITLE
Respect sidekiq_options overridden by .set

### DIFF
--- a/lib/sidekiq/debouncer/middleware/client.rb
+++ b/lib/sidekiq/debouncer/middleware/client.rb
@@ -36,7 +36,7 @@ module Sidekiq
         def debounce(klass, job)
           raise NotSupportedError, "perform_at is not supported with debounce" if job.key?("at")
 
-          options = debounce_options(klass)
+          options = debounce_options(klass, job)
           key = debounce_key(klass, job, options)
           time = (options[:time].to_f + Time.now.to_f).to_s
 
@@ -58,8 +58,9 @@ module Sidekiq
           "debounce/v3/#{klass.name}/#{result}"
         end
 
-        def debounce_options(klass)
-          options = klass.get_sidekiq_options["debounce"].transform_keys(&:to_sym)
+        def debounce_options(klass, job)
+          options = job.fetch("debounce") { klass.get_sidekiq_options["debounce"] }
+          options = options.transform_keys(&:to_sym)
 
           raise MissingArgumentError, "'by' attribute not provided" unless options[:by]
           raise MissingArgumentError, "'time' attribute not provided" unless options[:time]


### PR DESCRIPTION
Sidekiq provides a `Sidekiq::Job.set(…)` API which can override `sidekiq_options` set at the class level, on a job-by-job instance basis. Sidekiq does the work of merging the options from `set` with those from the class-level `sidekiq_options`, into the "job" (really a normalized hash) that's handed to the middleware. So if we first look there for any `debounce:` options, rather than going to the `klass.get_sidekiq_options`, we can respect any overrides from the `.set` API.

In this commit I left the `klass.get_sidekiq_options` as a fallback, though I'm not sure that's actually necessary.

NOTE: This Sidekiq does not (currently?) deeply-merged nested options.
I've asked about this elsewhere: https://github.com/sidekiq/sidekiq/discussions/6366